### PR TITLE
Like a collection, sort events should only ever be triggered if a comparator is actually defined.

### DIFF
--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -151,7 +151,7 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
 
         // save 'em
         this.models = newModels;
-        
+
         _.each(toRemove, function (model) {
             this.trigger('remove', model, this);
         }, this);
@@ -161,7 +161,7 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         }, this);
 
         // if they contain the same models, but in new order, trigger sort
-        if (!_.isEqual(existingModels, newModels)) {
+        if (this.comparator && !_.isEqual(existingModels, newModels)) {
             this.trigger('sort', this);
         }
     },

--- a/test/main.js
+++ b/test/main.js
@@ -369,3 +369,42 @@ test('reset works correctly/efficiently when passed to configure', function (t) 
 
     t.end();
 });
+
+test('it triggers sort events if comparator is defined and sort changes', function (t) {
+    var base = getBaseCollection();
+    var sub = new SubCollection(base, {
+        comparator: 'awesomeness'
+    });
+
+    var newWidget = new Widget({
+        name: 'lame',
+        id: 1000,
+        awesomeness: 0,
+        sweet: false
+    });
+
+    sub.on('sort', function () {
+        t.end();
+    });
+
+    base.add(newWidget);
+});
+
+test('it does not trigger sort events if no comparator is defined', function (t) {
+    var base = getBaseCollection();
+    var sub = new SubCollection(base);
+
+    var newWidget = new Widget({
+        name: 'lame',
+        id: 1000,
+        awesomeness: 0,
+        sweet: false
+    });
+
+    sub.on('sort', function () {
+        t.ok(false, 'Sort should not have been called');
+    });
+
+    base.add(newWidget);
+    t.end();
+});


### PR DESCRIPTION
Currently _any_ change to a subcollection triggers a sort, even if no comparator is defined on the subcollection. This is a) different to how a collection works, b) means excessive dom manipulation in collection views when rendering subcollections.
