### PR TITLE
Allow for bubbling models custom events to subcollections. Fix #25

### DIFF
--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -151,12 +151,14 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
 
         // save 'em
         this.models = newModels;
-        
+
         _.each(toRemove, function (model) {
+            this._removeReference(model);
             this.trigger('remove', model, this);
         }, this);
 
         _.each(toAdd, function (model) {
+            this._addReference(model);
             this.trigger('add', model, this);
         }, this);
 
@@ -175,6 +177,24 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         if ((_.contains(['sync', 'invalid', 'destroy']) || eventName.indexOf('change') !== -1) && this.contains(model)) {
             this.trigger.apply(this, arguments);
         }
+    },
+
+    // Internal method to create a model's ties to a collection.
+    _addReference: function (model) {
+        if (model.on) model.on('all', this._onModelEvent, this);
+    },
+
+    // Internal method to sever a model's ties to a collection.
+    _removeReference: function (model) {
+        if (model.off) model.off('all', this._onModelEvent, this);
+    },
+
+    _onModelEvent: function (event, model, collection, options) {
+        if (_.contains(['add', 'remove'], event) || event.indexOf('change') !== -1) {
+            return;
+        }
+
+        this.trigger.apply(this, arguments);
     }
 });
 

--- a/test/main.js
+++ b/test/main.js
@@ -308,6 +308,19 @@ test('should be able to listen for general `change` events on subcollection', fu
     cool.name = 'new name';
 });
 
+test('should be able to listen for custom events triggered by model', function (t) {
+    t.plan(2);
+    var model = new Widget();
+    var base = new Widgets([model]);
+    var sub = new SubCollection(base);
+    sub.on('customEvent', function (foo) {
+        t.deepEqual(foo, { random: 'option' });
+        t.pass('custom event triggered successfully');
+        t.end();
+    });
+    model.trigger('customEvent', { random: 'option' });
+});
+
 test('have the correct ordering saved when processing a sort event', function (t) {
     t.plan(3);
     var base = getBaseCollection();


### PR DESCRIPTION
I'm only not sure about which events should we check for on L193 as we've few more event types on models.

cc @latentflip https://github.com/AmpersandJS/ampersand-subcollection/issues/25