### PR TITLE
Collection api parity

### DIFF
--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -128,6 +128,12 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         }
         return models;
     },
+    // sort with own comparator
+    sort: function (options) {
+        if (!this.comparator) throw new Error('Cannot sort a set without a comparator');
+        options || (options = {});
+        this._sort();
+        if (!options.silent) this.trigger('sort', this, options);
         return this;
     },
 

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -200,7 +200,7 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
             this._runFilters();
         }
         // conditions under which we should proxy the events
-        if ((_.contains(['sync', 'invalid', 'destroy'], eventName) || eventName.indexOf('change') !== -1) && this.contains(model)) {
+        if (!_.contains(['add', 'remove'], eventName) && this.contains(model)) {
             this.trigger.apply(this, arguments);
         }
     }

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -188,7 +188,7 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         }, this);
 
         // unless we have the same models in same order trigger `sort`
-        if (!_.isEqual(existingModels, newModels)) {
+        if (!_.isEqual(existingModels, newModels) && this.comparator) {
             this.trigger('sort', this);
         }
     },

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -99,23 +99,35 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
     reset: function () {
         this.configure({}, true);
     },
-
-    // sort with own comparator or collection.comparator
-    sort: function (options) {
-        if (this.comparator) {
-            this.collection.sort.call(this, options);
-        } else if (this.collection.comparator) {
-            var oldComparator = this.comparator;
-            var err;
-            this.comparator = this.collection.comparator;
-            try {
-                this.collection.sort.call(this, options);
-            } catch (e) {
-                err = e;
-            }
-            this.comparator = oldComparator;
-            if (err) throw err;
+    _sort: function (models) {
+        var self = this;
+        models = models || this.models;
+        if (typeof this.comparator === 'string') {
+            models.sort(function (left, right) {
+                if (left.get) {
+                    left = left.get(self.comparator);
+                    right = right.get(self.comparator);
+                } else {
+                    left = left[self.comparator];
+                    right = right[self.comparator];
+                }
+                if (left > right || left === void 0) return 1;
+                if (left < right || right === void 0) return -1;
+                return 0;
+            });
+        } else if (this.comparator.length === 1) {
+            models.sort(function (left, right) {
+                left = self.comparator(left);
+                right = self.comparator(right);
+                if (left > right || left === void 0) return 1;
+                if (left < right || right === void 0) return -1;
+                return 0;
+            });
+        } else {
+            models.sort(this.comparator.bind(this));
         }
+        return models;
+    },
         return this;
     },
 
@@ -182,7 +194,7 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         }
 
         // sort it
-        if (this.comparator) newModels = _.sortBy(newModels, this.comparator);
+        if (this.comparator) newModels = this._sort(newModels);
 
         // trim it to length
         if (this.limit || this.offset) {

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -100,6 +100,25 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         this.configure({}, true);
     },
 
+    // sort with own comparator or collection.comparator
+    sort: function (options) {
+        if (this.comparator) {
+            this.collection.sort.call(this, options);
+        } else if (this.collection.comparator) {
+            var oldComparator = this.comparator;
+            var err;
+            this.comparator = this.collection.comparator;
+            try {
+                this.collection.sort.call(this, options);
+            } catch (e) {
+                err = e;
+            }
+            this.comparator = oldComparator;
+            if (err) throw err;
+        }
+        return this;
+    },
+
     // just reset filters, no model changes
     _resetFilters: function (resetComparator) {
         this._filters = [];

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -202,10 +202,11 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         // sort it
         if (this.comparator) newModels = this._sort(newModels);
 
+        // Cache a reference to the full filtered set to allow this.filtered.length. Ref: #6
+        this.filtered = newModels;
+
         // trim it to length
         if (this.limit || this.offset) {
-            // Cache a reference to the full filtered set to allow this.filtered.length. Ref: #6
-            this.filtered = newModels;
             newModels = newModels.slice(offset, this.limit + offset);
         }
 

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -218,6 +218,21 @@ Object.defineProperty(SubCollection.prototype, 'isCollection', {
     }
 });
 
+// Proxy model management methods directly to this.collection
+['add', 'parse', 'remove', 'set'].forEach(function (method) {
+    SubCollection.prototype[method] = function () {
+        return this.collection[method].apply(this.collection, arguments);
+    };
+});
+
+// Proxy serializing methods to this.collection's methods, but
+// with the subcollection's models
+['serialize', 'toJSON'].forEach(function (method) {
+    SubCollection.prototype[method] = function () {
+        return this.collection[method].apply(this, arguments);
+    };
+});
+
 SubCollection.extend = classExtend;
 
 module.exports = SubCollection;

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "underscore": "^1.6.0"
   },
   "devDependencies": {
-    "ampersand-collection": "~0.2.3",
-    "ampersand-state": "~0.3.1",
+    "ampersand-collection": "^1.3.17",
+    "ampersand-state": "^4.4.4",
     "jshint": "^2.5.5",
     "precommit-hook": "^1.0.7",
     "run-browser": "^1.3.1",

--- a/test/main.js
+++ b/test/main.js
@@ -797,19 +797,17 @@ test('sort', function (t) {
     sub.on('sort', function () { sortCount++; });
 
     // sort with sub's comparator
-    sub.comparator = function (a, b) { return a.awesomeness > b.awesomeness ? 1 : -1; };
+    sub.comparator = function (a, b) { 
+        return a.awesomeness > b.awesomeness ? 1 : (a.awesomeness < b.awesomeness ? -1 : 0); };
     sub.sort();
-    t.deepEqual(sub.models, _.chain(base.models).where({sweet: true}).sortBy(sub.comparator).value(), 'sorts with sub\'s comparator, if defined');
+    t.deepEqual(sub.models, _.chain(base.models).where({sweet: true}).value().sort(sub.comparator), 'sorts with sub\'s comparator, if defined');
 
-    // sort with base's comparator
-    sub.comparator = undefined;
-    base.comparator = 'awesomeness';
-    sub.sort();
-    t.deepEqual(sub.models, _.chain(base.models).where({sweet: true}).value(), 'sorts with base\'s comparator when sub has none');
 
     // no comparator
-    base.comparator = undefined;
-    sub.sort();
-    t.equal(sortCount, 2, 'does nothing when neither have a comparator');
+    sub.comparator = undefined;
+    t.throws(sub.sort.bind(sub), 'throws when sub doesn\'t have a comparator');
+
+
+    t.equal(sortCount, 1, 'sort event only triggered once');
     t.end();
 });

--- a/test/main.js
+++ b/test/main.js
@@ -574,6 +574,34 @@ test('clear filters', function (t) {
     t.end();
 });
 
+test('custom event bubbling', function (t) {
+
+    var base = getBaseCollection();
+    var sub = new SubCollection(base, {
+        where: {
+            sweet: true,
+            awesomeness: 6
+        }
+    });
+
+    var customCountBase = 0;
+    base.on('custom', function () {
+        customCountBase++;
+    });
+
+    var customCountSub = 0;
+    sub.on('custom', function () {
+        customCountSub++;
+    });
+
+    var model = sub.at(0);
+    model.trigger('custom', model);
+
+    t.equal(customCountBase, customCountSub, 'sub bubbled custom event');
+
+    t.end();
+});
+
 test('proxied methods where collection is `this`', function (t) {
     var base = getBaseCollection();
     var sub = new SubCollection(base, {

--- a/test/main.js
+++ b/test/main.js
@@ -202,7 +202,7 @@ test('should be able to specify/update offset and limit', function (t) {
     t.end();
 });
 
-test('should fire `add` events only if removed items match filter', function (t) {
+test('should fire `add` events only if added items match filter', function (t) {
     t.plan(1);
     var base = getBaseCollection();
     var sub = new SubCollection(base, {
@@ -510,9 +510,6 @@ test('reset', function (t) {
     sub.on('add', function (model) {
         itemsAdded.push(model);
     });
-    sub.on('sort', function () {
-        sortTriggered++;
-    });
 
     sub.reset();
 
@@ -522,7 +519,6 @@ test('reset', function (t) {
 
     t.deepEqual(sub._watched, [], 'should not be watching any properties');
     t.equal(sub.comparator, void 0, 'comparator should be undefined');
-    t.equal(sortTriggered, 1, 'should have triggered a `sort`');
 
     t.deepEqual(_.pluck(sub.models, 'id'), base.pluck('id'));
 


### PR DESCRIPTION
Addresses the following issues:

- #9 by adding collection methods: serialize and toJSON
- #23 by only sorting and triggering a sort event when there's a comparator
- #25 by bubbling all model events except add/remove as long as the model is in sub's models.

It also adds the following collection methods proxied through to its collection: add, remove, parse, set, and sort.

The method additions and event fixes should give us relatively complete parity with collection behaviour.