### PR TITLE
Remove underscore, use ampersand-events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+npm-debug.log

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -1,7 +1,16 @@
 /*$AMPERSAND_VERSION*/
-var _ = require('underscore');
 var Events = require('backbone-events-standalone');
+var _ = require('underscore');
 var classExtend = require('ampersand-class-extend');
+var contains = require('amp-contains');
+var difference = require('amp-difference');
+var each = require('amp-each');
+var extend = require('amp-extend');
+var flatten = require('amp-flatten');
+var isArray = require('amp-is-array');
+var isEqual = require('amp-is-object-equal');
+var keys = require('amp-keys');
+var reduce = require('amp-reduce');
 var underscoreMixins = require('ampersand-collection-underscore-mixin');
 var slice = Array.prototype.slice;
 
@@ -14,7 +23,7 @@ function SubCollection(collection, spec) {
 }
 
 
-_.extend(SubCollection.prototype, Events, underscoreMixins, {
+extend(SubCollection.prototype, Events, underscoreMixins, {
     // add a filter function directly
     addFilter: function (filter) {
         this.swapFilters([filter], []);
@@ -38,13 +47,13 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
 
         if (!oldFilters) {
             oldFilters = this._filters;
-        } else if (!_.isArray(oldFilters)) {
+        } else if (!isArray(oldFilters)) {
             oldFilters = [oldFilters];
         }
 
         if (!newFilters) {
             newFilters = [];
-        } else if (!_.isArray(newFilters)) {
+        } else if (!isArray(newFilters)) {
             newFilters = [newFilters];
         }
 
@@ -71,7 +80,7 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
     // }
     configure: function (opts, clear) {
         if (clear) this._resetFilters(clear);
-        //_.extend(this._spec, opts);
+        //extend(this._spec, opts);
         this._parseSpec(opts);
         this._runFilters();
     },
@@ -116,25 +125,25 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
 
     // adds a property or array of properties to watch, ensures uniquness.
     _watch: function (item) {
-        this._watched = _.union(this._watched, _.isArray(item) ? item : [item]);
+        this._watched = flatten([this._watched, item]);
     },
 
     // removes a watched property
     _unwatch: function (item) {
-        this._watched = _.difference(this._watched, _.isArray(item) ? item : [item]);
+        this._watched = difference(this._watched, isArray(item) ? item : [item]);
     },
 
     _parseSpec: function (spec) {
         if (spec.watched) this._watch(spec.watched);
         if (spec.comparator) this.comparator = spec.comparator;
         if (spec.where) {
-            _.each(spec.where, function (value, item) {
+            each(spec.where, function (value, item) {
                 this._addFilter(function (model) {
                     return (model.get ? model.get(item) : model[item]) === value;
                 });
             }, this);
             // also make sure we watch all `where` keys
-            this._watch(_.keys(spec.where));
+            this._watch(keys(spec.where));
         }
         if (spec.hasOwnProperty('limit')) this.limit = spec.limit;
         if (spec.hasOwnProperty('offset')) this.offset = spec.offset;
@@ -155,7 +164,7 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
 
         // reduce base model set by applying filters
         if (this._filters.length) {
-            newModels = _.reduce(this._filters, function (startingArray, filterFunc) {
+            newModels = reduce(this._filters, function (startingArray, filterFunc) {
                 return startingArray.filter(filterFunc);
             }, rootModels);
         } else {
@@ -173,22 +182,22 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
         }
 
         // now we've got our new models time to compare
-        toAdd = _.difference(newModels, existingModels);
-        toRemove = _.difference(existingModels, newModels);
+        toAdd = difference(newModels, existingModels);
+        toRemove = difference(existingModels, newModels);
 
         // save 'em
         this.models = newModels;
-        
-        _.each(toRemove, function (model) {
+
+        each(toRemove, function (model) {
             this.trigger('remove', model, this);
         }, this);
 
-        _.each(toAdd, function (model) {
+        each(toAdd, function (model) {
             this.trigger('add', model, this);
         }, this);
 
         // unless we have the same models in same order trigger `sort`
-        if (!_.isEqual(existingModels, newModels) && this.comparator) {
+        if (!isEqual(existingModels, newModels) && this.comparator) {
             this.trigger('sort', this);
         }
     },
@@ -196,11 +205,11 @@ _.extend(SubCollection.prototype, Events, underscoreMixins, {
     _onCollectionEvent: function (eventName, model) {
         var propName = eventName.split(':')[1];
         // conditions under which we should re-run filters
-        if (propName === this.comparator || _.contains(this._watched, propName) || _.contains(['add', 'remove', 'reset', 'sync'], eventName)) {
+        if (propName === this.comparator || contains(this._watched, propName) || contains(['add', 'remove', 'reset', 'sync'], eventName)) {
             this._runFilters();
         }
         // conditions under which we should proxy the events
-        if (!_.contains(['add', 'remove'], eventName) && this.contains(model)) {
+        if (!contains(['add', 'remove'], eventName) && this.contains(model)) {
             this.trigger.apply(this, arguments);
         }
     }

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -1,5 +1,5 @@
 /*$AMPERSAND_VERSION*/
-var Events = require('backbone-events-standalone');
+var Events = require('ampersand-events');
 var _ = require('underscore');
 var classExtend = require('ampersand-class-extend');
 var contains = require('amp-contains');

--- a/ampersand-subcollection.js
+++ b/ampersand-subcollection.js
@@ -10,6 +10,7 @@ var flatten = require('amp-flatten');
 var isArray = require('amp-is-array');
 var isEqual = require('amp-is-object-equal');
 var keys = require('amp-keys');
+var unique = require('amp-unique');
 var reduce = require('amp-reduce');
 var underscoreMixins = require('ampersand-collection-underscore-mixin');
 var slice = Array.prototype.slice;
@@ -125,7 +126,7 @@ extend(SubCollection.prototype, Events, underscoreMixins, {
 
     // adds a property or array of properties to watch, ensures uniquness.
     _watch: function (item) {
-        this._watched = flatten([this._watched, item]);
+        this._watched = unique(flatten([this._watched, item]));
     },
 
     // removes a watched property

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "amp-every": "^1.0.1",
     "amp-pluck": "^1.0.0",
     "amp-to-array": "^1.0.0",
-    "ampersand-collection": "~0.2.3",
-    "ampersand-state": "~0.3.1",
+    "ampersand-collection": "^1.0.0",
+    "ampersand-state": "^4.0.0",
     "jshint": "^2.5.5",
     "precommit-hook": "^1.0.7",
-    "run-browser": "^1.3.1",
-    "tap-spec": "^0.2.1",
-    "tape": "~2.12.0"
+    "run-browser": "^2.0.0",
+    "tap-spec": "^2.0.0",
+    "tape": "^3.0.0"
   },
   "homepage": "https://github.com/ampersandjs/ampersand-subcollection",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "amp-to-array": "^1.0.1",
     "ampersand-class-extend": "^1.0.0",
     "ampersand-collection-underscore-mixin": "^1.0.0",
+    "ampersand-events": "^1.0.0",
     "ampersand-version": "^1.0.0",
-    "backbone-events-standalone": "0.2.2",
     "underscore": "^1.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "amp-keys": "^1.0.1",
     "amp-reduce": "^1.0.0",
     "amp-to-array": "^1.0.1",
+    "amp-unique": "^1.0.1",
     "ampersand-class-extend": "^1.0.0",
     "ampersand-collection-underscore-mixin": "^1.0.0",
     "ampersand-events": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
     "url": "https://github.com/ampersandjs/ampersand-subcollection/issues"
   },
   "dependencies": {
+    "amp-contains": "^1.0.1",
+    "amp-difference": "^1.0.1",
+    "amp-each": "^1.0.1",
+    "amp-extend": "^1.0.1",
+    "amp-flatten": "^1.0.1",
+    "amp-is-array": "^1.0.1",
+    "amp-is-object-equal": "^1.0.2",
+    "amp-keys": "^1.0.1",
+    "amp-reduce": "^1.0.0",
+    "amp-to-array": "^1.0.1",
     "ampersand-class-extend": "^1.0.0",
     "ampersand-collection-underscore-mixin": "^1.0.0",
     "ampersand-version": "^1.0.0",
@@ -14,6 +24,9 @@
     "underscore": "^1.6.0"
   },
   "devDependencies": {
+    "amp-every": "^1.0.1",
+    "amp-pluck": "^1.0.0",
+    "amp-to-array": "^1.0.0",
     "ampersand-collection": "~0.2.3",
     "ampersand-state": "~0.3.1",
     "jshint": "^2.5.5",


### PR DESCRIPTION
This is the start of removing underscore and the backbone events standalone from this module.

We still need an analog to sortBy in amp, and it looks like we just need https://github.com/AmpersandJS/object-sort rolled into amp

Also updates some dev dependencies.

This technically still leaves underscore in because of underscore-mixin but that can be fixed in that module separately.